### PR TITLE
fix: add set edit row id to 0

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,7 @@ function App() {
               fetchAppointments={fetchAppointments}
               setEditAppointment={setEditAppointment}
               appointments={appointments}
+              setEditRowId={setEditRowId}
             />
           </Box>
         </Box>

--- a/src/components/AppointmentForm.tsx
+++ b/src/components/AppointmentForm.tsx
@@ -27,6 +27,7 @@ interface AppointmentTypes {
 interface AppointmentFormProps {
   editAppointment: AppointmentTypes | undefined;
   setEditAppointment: (appointment: AppointmentTypes | undefined) => void;
+  setEditRowId: (id: number) => void;
   fetchAppointments: () => void;
   appointments: AppointmentTypes[];
 }
@@ -39,10 +40,18 @@ interface FormDataTypes {
 }
 
 const AppointmentForm = (props: AppointmentFormProps) => {
-  const { editAppointment, setEditAppointment, fetchAppointments, appointments } = props;
+  const {
+    editAppointment,
+    setEditAppointment,
+    setEditRowId,
+    fetchAppointments,
+    appointments
+  } = props;
+
   const [key, setKey] = useState<number>(0)
   const [isStartDateOverlap, setIsStartDateOverlap] = useState<boolean>(false);
   const [isEndDateOverlap, setIsEndDateOverlap] = useState<boolean>(false);
+  
   const {
     control,
     formState: { errors },
@@ -131,6 +140,7 @@ const AppointmentForm = (props: AppointmentFormProps) => {
         if (response.status === 200) {
           fetchAppointments();
           setEditAppointment(undefined);
+          setEditRowId(0);
           alert('Appointment Updated Successfully');
           reset();
           setKey(prevKey => prevKey + 1);


### PR DESCRIPTION
# Pull Request for Appointments Frontend

## Description
- Added setRowId to 0 at AppointmentForm.tsx to refresh the row/appointment to default.

## Type of Change
- [ ] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [x] Refactor Code
- [x] Bug fix
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify)